### PR TITLE
Cleaned up client (especially query strings)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 reqwest = { version = "0.11", features = ["json"]}
-cities-common = { path = "../cities-common" }
+cities-common = { path = "../cities-common", feature=["sqlxrow"]}


### PR DESCRIPTION
I created a client in client.rs since reqwest::get creates a new one each time, it was just something to get started quickly. This also allows us to use requestbuilder and the query method: https://docs.rs/reqwest/latest/reqwest/struct.RequestBuilder.html#method.query

I also added some TODO in comments